### PR TITLE
Use the Current Level Value When Input Null

### DIFF
--- a/Govee/Govee_Immersion_LED_Strip.groovy
+++ b/Govee/Govee_Immersion_LED_Strip.groovy
@@ -112,7 +112,11 @@ def setColor(value) {
 
 def setHsb(h,s,b)
 {
-
+	if(!b){
+		currentLevel = device.currentValue("level")?.toInteger()
+		log.debug "No level specified; using current level: ${currentLevel}"
+		b = currentLevel
+    	}
 	hsbcmd = [h,s,b]
 //	log.debug "Cmd = ${hsbcmd}"
 


### PR DESCRIPTION
I noticed that one of the dashboard integrations is only sending two of the three values in it's color command event and it was causing an unhandled exception. Adding a null replacement value using the current level so that the driver is able to complete the color change without error.